### PR TITLE
Implements fmt::Display for ClamError

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types, dead_code)]
 
-use libc::c_uint;
+use libc::{c_char, c_int, c_uint};
 
 pub const CL_INIT_DEFAULT: u32 = 0x0;
 
@@ -8,6 +8,7 @@ pub const CL_INIT_DEFAULT: u32 = 0x0;
 #[link(name = ":libclamav.so.7")]
 extern "C" {
     pub fn cl_init(initOptions: c_uint) -> cl_error;
+    pub fn cl_strerror(clerror: c_int) -> *const c_char;
 }
 
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,39 @@
 extern crate libc;
 
+use std::ffi::CStr;
+use std::fmt;
+use std::str;
+
 mod ffi;
 
 /// An error indicating a clam failure.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ClamError {
-    code: u32,
+    code: i32,
 }
 
 impl ClamError {
     pub fn new(native_err: ffi::cl_error) -> Self {
         ClamError {
-            code: native_err as u32,
+            code: native_err as i32,
         }
+    }
+
+    fn string_error(&self) -> String {
+        unsafe {
+            let ptr = ffi::cl_strerror(self.code);
+            let bytes = CStr::from_ptr(ptr).to_bytes();
+            str::from_utf8(bytes)
+                .ok()
+                .expect("Invalid UTF8 string")
+                .to_string()
+        }
+    }
+}
+
+impl fmt::Display for ClamError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "cl_error {}: {}", self.code, self.string_error())
     }
 }
 
@@ -36,5 +57,15 @@ mod tests {
     #[test]
     fn initialize_success() {
         assert!(initialize().is_ok(), "initialize should succeed");
+    }
+
+    #[test]
+    fn error_as_string_success() {
+        let err = ClamError::new(ffi::cl_error::CL_EFORMAT);
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("CL_EFORMAT"),
+            "error description should contain string error"
+        );
     }
 }


### PR DESCRIPTION
This allows consumers to get the "friendly" message without pre-allocating it.