### PR TITLE
Run freshclam explicitly in travis-ci 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ rust:
   - beta
   - nightly
 before_install:
-  - sudo apt-get install -y clamav
+  - sudo apt-get install -y libclamav7 clamav-freshclam
+  # Stop freshclam running automatically
+  - sudo dpkg-reconfigure clamav-freshclam
+  # Run now so we know it's up to date
+  - sudo freshclam -v
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::str;
 use ffi;
 
 /// An error indicating a clam failure.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ClamError {
     code: i32,
 }
@@ -32,6 +32,12 @@ impl ClamError {
 impl fmt::Display for ClamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "cl_error {}: {}", self.code, self.string_error())
+    }
+}
+
+impl fmt::Debug for ClamError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.to_string())
     }
 }
 


### PR DESCRIPTION
This prevents the tests running before the database is up to date